### PR TITLE
Updated workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-    reviewers:
-      - "Fank"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    reviewers:
-      - "Fank"
+      interval: "weekly"

--- a/.github/templates/go-licenses.md.tpl
+++ b/.github/templates/go-licenses.md.tpl
@@ -1,0 +1,5 @@
+## [go-licenses](https://github.com/google/go-licenses) report
+
+{{- range . }}
+- {{ .Name }} ({{ .Version }}) [{{ .LicenseName }}]({{ .LicenseURL }})
+{{- end }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v2.1.0, etc.
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changelog }}  # Attach changelog

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: Go Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,12 +33,11 @@ jobs:
             ${{ runner.os }}-golang-
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
+        uses: golangci/golangci-lint-action@v8
 
   test:
     runs-on: ubuntu-latest
+    name: Go Test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -61,33 +60,3 @@ jobs:
 
       - name: Test
         uses: robherley/go-test-action@v0
-        with:
-          testArguments: ./...
-
-  license-check:
-    runs-on: ubuntu-latest
-    name: License Check
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./go.mod
-
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
-        shell: bash
-
-      - name: Check licenses
-        run: >
-          go-licenses check ./...
-          --ignore ${{ github.repository }}
-        shell: bash
-
-      - name: Get licenses list
-        run: >
-          go-licenses csv ./...
-          --ignore ${{ github.repository }}
-        shell: bash

--- a/.github/workflows/license_go.yml
+++ b/.github/workflows/license_go.yml
@@ -1,0 +1,49 @@
+name: License Go
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    name: License Check
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Check licenses
+        run: go-licenses check ./...
+
+  license-report:
+    runs-on: ubuntu-latest
+    name: License Report
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Report to GitHub Step Summary
+        run: >
+          go-licenses report ./...
+          --template .github/templates/go-licenses.md.tpl
+          >> $GITHUB_STEP_SUMMARY
+        shell: bash


### PR DESCRIPTION
This pull request introduces several updates to the repository's GitHub Actions workflows, Dependabot configuration, and license management. The changes aim to improve workflow organization, adjust update schedules, and enhance license reporting. Below is a summary of the most significant changes:

### Workflow Updates and Enhancements:
* Added a new `changelog.yml` workflow to automate creating GitHub releases with a changelog generated using the `release-changelog-builder-action`. This workflow triggers on version tags (e.g., `v1.0.0`). (`[.github/workflows/changelog.ymlR1-R33](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R1-R33)`)
* Split the license-check functionality from the `go.yml` workflow into a dedicated `license_go.yml` workflow. This new workflow includes separate jobs for license checking and generating a license report using the `go-licenses` tool. (`[.github/workflows/license_go.ymlR1-R49](diffhunk://#diff-4086cd651c06d7a18d9940946971a0bff2d4c636298ab9688c723a93cb11417aR1-R49)`)
* Updated the `go.yml` workflow:
  - Renamed job names for better clarity (e.g., `lint` -> `Go Lint`, `test` -> `Go Test`). (`[[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL16-R16)`, `[[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL36-R40)`)
  - Upgraded the `golangci-lint-action` version from `v6` to `v8`. (`[.github/workflows/go.ymlL36-R40](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL36-R40)`)
  - Removed the `license-check` job, as it was moved to `license_go.yml`. (`[.github/workflows/go.ymlL64-L93](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL64-L93)`)

### Dependabot Configuration:
* Updated the update schedule for `gomod` and `github-actions` package ecosystems from daily to weekly, and removed reviewers from the configuration. (`[.github/dependabot.ymlL6-R11](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R11)`)

### License Management:
* Added a new template file, `go-licenses.md.tpl`, to format the output of the `go-licenses` tool into a markdown report. (`[.github/templates/go-licenses.md.tplR1-R5](diffhunk://#diff-ff560d5d3ad99824bd9294a7b7b013edd79c731be891ef1ab2b9b6b9949bbc49R1-R5)`)